### PR TITLE
Update post categories only if others found

### DIFF
--- a/inc/process-notes.php
+++ b/inc/process-notes.php
@@ -137,7 +137,8 @@ function rksnwp_post_category( $post, $tags ){
 			}
 		}
 	}
-	$post['post_category'] = $postCats;
+	if (count($postCasts) > 0)
+  	$post['post_category'] = $postCats;
 	return $post;
 }
 add_action('sentinote_process_wp_post_data', 'rksnwp_post_category', 10, 2);


### PR DESCRIPTION
If a default category is selected, it never actually gets used, as the post's <code>post_category</code> gets replaced during <code>rksnwp_post_category</code>.

This update simply updates the <code>post_category</code> only if there categories to set.
